### PR TITLE
Add Docker / Docker Desktop support (build + run)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+.git
+.gitignore
+*.md
+CHANGELOG.md
+TODO.md
+README
+
+# Não precisamos do binário pré-compilado nem dos arquivos de dados runtime
+# dentro do contexto de build -- o Dockerfile compila o binário do zero e
+# só copia game.conf/game.motd de bin/ como defaults.
+bin/tetrix-modern.linux
+bin/game.log
+bin/game.pid
+bin/game.winlist
+bin/game.secure
+
+# Cliente Windows não é usado pela imagem do servidor
+tetrinet_windows_client_v1.13/
+
+contrib/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@
   lista interna recebesse a winlist atualizada. Corrigido para
   `n == NULL`, permitindo que o laço percorra toda a lista de jogadores
   quando o destino é "todos".
+- **Added:** suporte para compilar e rodar o servidor com **Docker /
+  Docker Desktop** (`docker/`), incluindo:
+  - `Dockerfile`: build multi-stage (compila com `gcc` em uma etapa,
+    imagem final enxuta rodando com usuário sem privilégios).
+  - `entrypoint.sh`: lida com o fato de o binário fazer seu próprio
+    "double-fork" ao daemonizar (incompatível com o modelo padrão de
+    container), mantendo o container em primeiro plano enquanto o
+    processo real do servidor estiver vivo, e repassando
+    `SIGTERM`/`SIGINT` corretamente.
+  - `docker-compose.yml`: forma recomendada de uso no Docker Desktop,
+    já com portas, volume persistente (`/data`) e `init: true`
+    configurados.
+  - `README.md`: instruções de uso completas, incluindo a explicação
+    do porquê de precisar de `--init`/`init: true` (evitar zumbis
+    gerados pelo double-fork do binário em containers sem um init de
+    verdade como PID 1).
+  - `.dockerignore` (raiz do repo): contexto de build enxuto, sem
+    `.git`, binário pré-compilado, cliente Windows, etc.
+- **Changed:** `README` principal agora também aponta para
+  `docker/README.md`.
 - **Added:** suporte a gerenciar o servidor como serviço `systemd` no
   Linux (`contrib/systemd/`), incluindo:
   - `tetrinetx.service`: unit file (`Type=forking`, já que o binário faz

--- a/README
+++ b/README
@@ -57,3 +57,11 @@ Running as a systemd service (Linux)
 
 To manage the server with systemctl (start/stop/restart/status) instead of
 running it manually, see contrib/systemd/README.md.
+
+
+___________________________________________________________________________
+
+Running with Docker / Docker Desktop
+
+To build and run the server in a container instead of compiling it
+locally, see docker/README.md.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+#
+# TetriNET X Modern Server - Docker build
+#
+# Uso (a partir da raiz do repositório):
+#   docker build -f docker/Dockerfile -t tetrinetx .
+#   docker run -d --init --name tetrinetx -p 31457:31457 -p 31456:31456 tetrinetx
+#
+# O --init é importante: o binário do tetrinetx faz seu próprio "double-fork"
+# ao daemonizar (ver docker/entrypoint.sh e docker/README.md), e sem um init
+# de verdade como PID 1 do container, o processo órfão gerado por esse
+# double-fork pode ficar temporariamente como zumbi até ser colhido.
+#
+# Veja docker/README.md para docker-compose e mais detalhes.
+
+# ---------------------------------------------------------------------------
+# Etapa 1: build - compila o binario com o compilador C
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04 AS build
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends gcc && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY src/ ./src/
+
+# O script original tem quebras de linha CRLF; normalizamos antes de rodar.
+RUN sed -i -e 's/\r$//' src/compile.linux && \
+    mkdir -p bin && \
+    cd src && bash compile.linux
+
+# ---------------------------------------------------------------------------
+# Etapa 2: runtime - imagem final, enxuta, sem toolchain de compilacao
+# ---------------------------------------------------------------------------
+FROM ubuntu:24.04 AS runtime
+
+# Usuario/grupo dedicados, sem privilegios de login (mesma logica usada em
+# contrib/systemd/install-tetrinetx-service.sh para a instalacao via systemd)
+RUN groupadd --system tetrinetx && \
+    useradd --system --gid tetrinetx --home-dir /opt/tetrinetx \
+            --no-create-home --shell /usr/sbin/nologin tetrinetx
+
+# /opt/tetrinetx = binario + arquivos de configuracao padrao (imagem, somente leitura na pratica)
+# /data          = diretorio de trabalho real do servidor, feito para ser montado como volume
+WORKDIR /opt/tetrinetx
+
+COPY --from=build /src/bin/tetrix-modern.linux ./tetrix-modern.linux
+COPY bin/game.conf ./defaults/game.conf
+COPY bin/game.motd ./defaults/game.motd
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN mkdir -p /data && \
+    chmod +x /usr/local/bin/entrypoint.sh ./tetrix-modern.linux && \
+    chown -R tetrinetx:tetrinetx /opt/tetrinetx /data
+
+USER tetrinetx
+
+# 31457 = porta do jogo (telnet), 31456 = porta de query (ver src/main.h)
+EXPOSE 31457/tcp 31456/tcp
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,173 @@
+# Rodando o tetrinetx com Docker / Docker Desktop
+
+Esta pasta contém os arquivos para compilar e rodar o **TetriNET X Modern
+Server** dentro de um container Docker.
+
+## Arquivos
+
+- `Dockerfile` — build multi-stage: compila o binário com `gcc` (Ubuntu
+  24.04) em uma etapa, e copia só o binário + configs para uma imagem final
+  enxuta, rodando com um usuário sem privilégios.
+- `entrypoint.sh` — script de entrada do container (ver explicação abaixo,
+  seção "Por que existe um entrypoint.sh").
+- `docker-compose.yml` — forma mais simples de subir o serviço, já com
+  portas e volume configurados; é o caminho recomendado para uso no Docker
+  Desktop.
+- `../.dockerignore` (raiz do repo) — evita levar `.git`, binário antigo,
+  cliente Windows, etc. para o contexto de build.
+
+## Pré-requisitos
+
+- **Docker Desktop** instalado e aberto (Windows, macOS ou Linux).
+- Não precisa ter `gcc` nem nada de toolchain C instalado na sua máquina —
+  tudo isso acontece dentro do container de build.
+
+## Uso rápido (recomendado): docker compose
+
+A partir da **raiz do repositório**:
+
+```bash
+docker compose -f docker/docker-compose.yml up -d --build
+```
+
+Isso vai:
+1. Compilar a imagem (`gcc` + `compile.linux`, exatamente como descrito no
+   `README` principal do projeto).
+2. Subir o container `tetrinetx` em segundo plano.
+3. Publicar as portas `31457` (jogo) e `31456` (query) em `localhost`.
+4. Criar um volume Docker `tetrinetx-data` para persistir `game.conf`,
+   `game.motd`, `game.winlist`, `game.log` e `game.pid` entre reinícios.
+
+Outros comandos úteis:
+
+```bash
+docker compose -f docker/docker-compose.yml logs -f      # acompanhar logs em tempo real
+docker compose -f docker/docker-compose.yml restart      # reiniciar o servidor
+docker compose -f docker/docker-compose.yml down         # parar e remover o container (mantém o volume/dados)
+docker compose -f docker/docker-compose.yml down -v      # parar e remover TAMBÉM o volume (apaga winlist/config)
+```
+
+## Usando o Docker Desktop (interface gráfica)
+
+Depois de rodar o `docker compose up -d --build` uma primeira vez pelo
+terminal, o dia a dia pode ser feito direto pela interface do Docker
+Desktop:
+
+- Aba **Containers**: veja o container `tetrinetx` rodando, com as portas
+  `31457`/`31456` mapeadas, o status (running/stopped) e um botão para
+  **Start / Stop / Restart**.
+- Clique no nome do container para ver **Logs** em tempo real (equivalente
+  ao `docker compose logs -f`) e a aba **Files**, onde dá pra navegar até
+  `/data` e conferir/editar `game.conf`, `game.motd`, `game.log` e
+  `game.winlist` diretamente pela interface.
+- Aba **Volumes**: o volume `tetrinetx-data` aparece listado, com os
+  mesmos arquivos.
+- Aba **Images**: a imagem `tetrinetx:local` fica disponível para rebuild
+  (botão de rebuild ou apagar/recriar).
+
+## Uso sem docker-compose (docker build / docker run direto)
+
+Também a partir da raiz do repositório:
+
+```bash
+docker build -f docker/Dockerfile -t tetrinetx .
+docker run -d --init --name tetrinetx \
+  -p 31457:31457 -p 31456:31456 \
+  -v tetrinetx-data:/data \
+  tetrinetx
+```
+
+> **Por que `--init`?** Ver a seção "Zumbis e o `--init`" mais abaixo.
+
+```bash
+docker logs -f tetrinetx      # ver logs
+docker restart tetrinetx      # reiniciar
+docker stop tetrinetx         # parar
+docker start tetrinetx        # iniciar de novo
+docker rm -f tetrinetx        # remover o container (mantém o volume)
+```
+
+## Editando a configuração (`game.conf` / `game.motd`)
+
+Os arquivos ficam no volume `tetrinetx-data`, montado em `/data` dentro do
+container. Para editar `game.conf` (por exemplo, mudar `maxchannels` ou
+`verbose`) sem precisar reconstruir a imagem:
+
+```bash
+docker compose -f docker/docker-compose.yml exec tetrinetx sh -c "cat /data/game.conf"
+```
+
+Edite localmente e copie de volta, ou edite diretamente pela aba **Files**
+do Docker Desktop (Containers → tetrinetx → Files → `/data`). Depois,
+reinicie o container para a nova configuração ser lida:
+
+```bash
+docker compose -f docker/docker-compose.yml restart
+```
+
+## Por que existe um `entrypoint.sh`?
+
+O binário do `tetrinetx` já faz seu próprio *daemonize* internamente: ele
+dá `fork()` duas vezes, fecha `stdin`/`stdout`/`stderr` e o processo "pai"
+(o que foi chamado originalmente) termina assim que o daemon real sobe em
+segundo plano — isso é visível em `src/main.c` (`writepid()` e a lógica
+logo antes dele).
+
+Isso conflita com o modelo padrão de containers, onde o **Docker espera
+que o processo principal (PID 1) continue rodando em primeiro plano** — se
+simplesmente chamássemos o binário direto como `ENTRYPOINT`, o container
+encerraria imediatamente, pois o processo que o Docker está observando sai
+na hora, mesmo com o servidor real ainda rodando em segundo plano.
+
+O `entrypoint.sh` contorna isso:
+1. Inicia o binário normalmente (ele mesmo daemoniza e retorna na hora).
+2. Espera o arquivo `game.pid` aparecer.
+3. Fica em primeiro plano acompanhando o log e monitorando se o processo
+   real (PID do `game.pid`) continua vivo.
+4. Quando esse processo cai (por erro ou por ter recebido `SIGTERM`), o
+   script também encerra — e o container reflete corretamente o estado
+   real do servidor (parado = parado, rodando = rodando).
+
+## Sobre o diretório de dados (`/data`) vs. a imagem (`/opt/tetrinetx`)
+
+- `/opt/tetrinetx` dentro da imagem contém o binário compilado e uma cópia
+  "modelo" de `game.conf`/`game.motd` em `/opt/tetrinetx/defaults/`.
+- `/data` é o diretório de trabalho real do servidor (onde ele lê/escreve
+  `game.conf`, `game.motd`, `game.winlist`, `game.log`, `game.pid`) e é o
+  que fica no volume Docker.
+- Na primeira execução, o `entrypoint.sh` copia os arquivos de
+  `defaults/` para `/data` **somente se ainda não existirem lá** — assim,
+  qualquer alteração que você fizer em `/data/game.conf` é preservada entre
+  reinícios e rebuilds da imagem.
+
+## Zumbis e o `--init`
+
+O binário do `tetrinetx` daemoniza dando `fork()` **duas vezes**: o
+processo intermediário sai logo depois do segundo fork, deixando o
+processo neto (o servidor de verdade) órfão, que é então "adotado" pelo
+processo `init` do sistema (normalmente PID 1), cuja responsabilidade é
+"colher" (`wait()`) os processos órfãos quando eles terminam, liberando a
+entrada deles da tabela de processos.
+
+Um container Docker, por padrão, **não tem um init de verdade como PID
+1** — o próprio `entrypoint.sh` (ou o binário) assume esse papel. Isso
+significa que, sem ajuda, um processo órfão criado por esse double-fork
+pode ficar temporariamente como **zumbi** (`<defunct>`) depois de
+terminar, até que alguém o colha.
+
+A solução padrão do Docker para isso é a flag `--init` (equivalente à
+opção `init: true` no `docker-compose.yml`, já configurada aqui), que
+injeta um init minimalista (`tini`) como PID 1 do container — feito
+exatamente para colher órfãos e zumbis corretamente. Por isso ela já
+vem habilitada por padrão no `docker-compose.yml` deste projeto, e é
+recomendada também no `docker run` direto.
+
+## Portas
+
+O servidor escuta por padrão em duas portas (definidas em `src/main.h`):
+
+- `31457/tcp` — porta do jogo (telnet/protocolo TetriNET)
+- `31456/tcp` — porta de query
+
+Ambas já vêm expostas (`EXPOSE`) no `Dockerfile` e publicadas
+(`ports:`) no `docker-compose.yml`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+# TetriNET X Modern Server - docker-compose
+#
+# Uso (a partir da raiz do repositório, com o Docker Desktop rodando):
+#   docker compose -f docker/docker-compose.yml up -d --build
+#   docker compose -f docker/docker-compose.yml logs -f
+#   docker compose -f docker/docker-compose.yml down
+#
+# No Docker Desktop, depois do "up", o serviço "tetrinetx" aparece na aba
+# Containers, com os logs e as portas mapeadas visíveis na interface.
+
+services:
+  tetrinetx:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: tetrinetx:local
+    container_name: tetrinetx
+    restart: unless-stopped
+    # Importante: o binário faz seu próprio "double-fork" ao daemonizar (ver
+    # docker/entrypoint.sh e docker/README.md). Sem um init de verdade como
+    # PID 1 do container, o processo órfão gerado por esse double-fork pode
+    # ficar temporariamente como zumbi até ser colhido. init: true ativa o
+    # tini embutido do Docker para lidar com isso corretamente.
+    init: true
+    ports:
+      - "31457:31457"   # porta do jogo (telnet)
+      - "31456:31456"   # porta de query
+    volumes:
+      # Persiste winlist, log e config entre reinícios do container.
+      # Comente esta linha se preferir um container totalmente "stateless".
+      - tetrinetx-data:/data
+
+volumes:
+  tetrinetx-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# entrypoint.sh
+#
+# O binario do tetrinetx faz seu proprio "daemonize" (da fork() duas vezes,
+# fecha stdin/stdout/stderr e o processo pai termina imediatamente -- e
+# assim que ele grava o PID em game.pid, ver src/main.c:writepid()).
+#
+# Isso e incompativel com o modelo padrao de container, onde o Docker espera
+# que o processo principal (PID 1) fique rodando em primeiro plano: se a
+# gente so chamasse o binario direto, o container encerraria na hora, pois
+# o processo "pai" (o que o Docker esta observando) sai assim que o daemon
+# real sobe em segundo plano.
+#
+# Este script contorna isso:
+#   1. Inicia o binario normalmente (ele mesmo daemoniza e retorna na hora)
+#   2. Espera o arquivo game.pid aparecer
+#   3. Fica em primeiro plano monitorando se o processo (PID do game.pid)
+#      continua vivo -- e assim que ele cair (crash ou SIGTERM tratado),
+#      o container encerra tambem, refletindo o estado real do servico.
+#   4. Repassa SIGTERM/SIGINT recebidos pelo Docker para o processo real.
+#
+set -euo pipefail
+
+APPDIR="/opt/tetrinetx"
+DATADIR="/data"
+BINARY="${APPDIR}/tetrix-modern.linux"
+PIDFILE="${DATADIR}/game.pid"
+LOGFILE="${DATADIR}/game.log"
+
+# Copia os arquivos de configuracao padrao para o diretorio de dados na
+# primeira execucao, sem sobrescrever o que ja existir la (permite editar
+# game.conf/game.motd no volume montado e persistir entre reinicios).
+mkdir -p "${DATADIR}"
+for f in game.conf game.motd; do
+  if [[ ! -f "${DATADIR}/${f}" && -f "${APPDIR}/defaults/${f}" ]]; then
+    cp "${APPDIR}/defaults/${f}" "${DATADIR}/${f}"
+  fi
+done
+
+cd "${DATADIR}"
+
+cleanup() {
+  if [[ -f "${PIDFILE}" ]]; then
+    local pid
+    pid="$(cat "${PIDFILE}" 2>/dev/null || true)"
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+      kill -TERM "${pid}" 2>/dev/null || true
+    fi
+  fi
+}
+trap cleanup SIGTERM SIGINT
+
+echo "Iniciando tetrinetx..."
+"${BINARY}"
+
+# Espera o processo daemonizado escrever o PID (normalmente e quase
+# instantaneo, mas damos uma folga generosa)
+for _ in $(seq 1 50); do
+  [[ -f "${PIDFILE}" ]] && break
+  sleep 0.1
+done
+
+if [[ ! -f "${PIDFILE}" ]]; then
+  echo "Erro: o servidor nao gravou ${PIDFILE} -- provavelmente falhou ao iniciar." >&2
+  exit 1
+fi
+
+SERVER_PID="$(cat "${PIDFILE}")"
+echo "tetrinetx rodando com PID ${SERVER_PID} (log em ${LOGFILE})"
+
+# Mantem o container em primeiro plano acompanhando o log (se/quando
+# existir) e monitorando se o processo real ainda esta vivo.
+touch "${LOGFILE}"
+tail -F "${LOGFILE}" &
+TAIL_PID=$!
+
+while kill -0 "${SERVER_PID}" 2>/dev/null; do
+  sleep 1
+done
+
+echo "tetrinetx (PID ${SERVER_PID}) encerrou."
+kill "${TAIL_PID}" 2>/dev/null || true


### PR DESCRIPTION
- docker/Dockerfile: multi-stage build. Stage 1 compiles the server with gcc on ubuntu:24.04 (reusing src/compile.linux, CRLF-normalized). Stage 2 copies just the binary + default game.conf/game.motd into a slim runtime image, running as a dedicated non-root user (same pattern as contrib/systemd/install-tetrinetx-service.sh).
- docker/entrypoint.sh: the binary daemonizes itself (double fork, closes stdio, parent exits immediately -- see src/main.c writepid()), which is incompatible with Docker's model of a foreground PID 1. This script starts the binary, waits for game.pid, then stays in the foreground tailing the log and monitoring the real server PID so the container's lifecycle matches the server's actual state; it also forwards SIGTERM/SIGINT to the real server process.
- docker-compose.yml: recommended way to run this on Docker Desktop. Ports 31457/31456 published, named volume mounted at /data (kept separate from /opt/tetrinetx so the volume never shadows the binary), init: true enabled.
- docker/README.md: full usage (compose and plain docker build/run), Docker Desktop walkthrough (Containers/Logs/Files/Volumes tabs), and an explanation of why --init/init: true matters here: the binary's own double-fork can leave a briefly zombied orphan process without a real init as PID 1 to reap it -- this was actually observed while testing entrypoint.sh's SIGTERM handling in a plain (non-Docker) sandbox and is a well-known Docker consideration for self-daemonizing binaries.
- .dockerignore: keep the build context slim (.git, prebuilt binary, Windows client, contrib/, etc excluded).
- README: pointer to docker/README.md.
- CHANGELOG.md: documented all of the above.

Verified without Docker available in this sandbox (validated the pieces that don't require the Docker daemon itself):
- Reproduced the exact build stage manually (gcc on the same src/compile.linux) -> confirmed binary output path, fixed a wrong COPY --from=build path in the process (was /bin/..., corrected to /src/bin/...).
- Reproduced the runtime directory layout (/opt/tetrinetx + /data) and ran entrypoint.sh directly: confirms defaults are copied to /data on first run only, game.pid/game.log/game.secure/game.winlist are written to /data, the server accepts a TCP connection on 31457, and SIGTERM sent to entrypoint.sh is correctly forwarded to the real server PID (observed 'Got TERM Signal - Quitting' in the log and the entrypoint's monitor loop exiting afterwards).
- bash -n on entrypoint.sh and python yaml.safe_load on docker-compose.yml both pass.