### PR TITLE
Fix Docker build: install build-essential instead of gcc alone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,18 @@ Maintainer / Developer: Alexandro G. Corrêa <alex.linux@gmail.com>
   above, plus `/topic`/`/list`/`/join`/`/msg`/`/move`/`/set`, starting a
   game and winning, and the single-player endgame fix).
 
+### Docker build fix: missing libc headers (`signal.h` and friends)
+
+- `contrib/docker/Dockerfile`'s build stage installed only the `gcc`
+  package (with `--no-install-recommends`), which on Ubuntu only
+  *recommends* `libc6-dev` rather than depending on it -- so the C
+  library headers (`signal.h`, etc, all of `src/main.h`'s includes)
+  were missing, and the build failed with `fatal error: signal.h: No
+  such file or directory`. Switched to installing `build-essential`
+  instead, which properly `Depends:` on `libc6-dev` (confirmed via
+  `apt-cache depends` on both packages) alongside `gcc`, `g++`, `make`,
+  and `dpkg-dev`.
+
 ### `docker/` and `tests/` moved into `contrib/`
 
 - Both folders moved to `contrib/docker/` and `contrib/tests/`

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -18,8 +18,12 @@
 # ---------------------------------------------------------------------------
 FROM ubuntu:24.04 AS build
 
+# build-essential (não só "gcc") -- garante libc6-dev junto (headers como
+# signal.h, stdio.h, etc), que o pacote "gcc" sozinho nem sempre traz com
+# --no-install-recommends. Sem isso o build falha com
+# "fatal error: signal.h: No such file or directory".
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc && \
+    apt-get install -y --no-install-recommends build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src


### PR DESCRIPTION
The build stage's 'apt-get install -y --no-install-recommends gcc' failed to pull in libc6-dev (the C library headers -- signal.h, stdio.h, etc, everything src/main.h includes), because on Ubuntu the gcc package only Recommends: libc6-dev rather than Depends: on it -- and --no-install-recommends explicitly skips recommendations. Result: 'fatal error: signal.h: No such file or directory' as soon as compile.linux tried to build main.c.

Confirmed via 'apt-cache depends gcc' (Recommends: libc6-dev) vs 'apt-cache depends build-essential' (Depends: libc6-dev, gcc, g++, make, dpkg-dev) -- switched to build-essential, which depends on libc6-dev for real.

Documented in CHANGELOG.md. Re-ran the local (non-Docker) build via src/compile.linux to confirm the source itself is unaffected (same pre-existing warning class only) -- Docker itself isn't available in this sandbox, so the Dockerfile fix couldn't be re-validated end to end here, but the diagnosis is confirmed via the package dependency metadata above, and this is the standard, well-known fix for this exact class of error.