### PR TITLE
Docker packaging fixes, protocol bug fixes, and colored MOTD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 game.log
 game.pid
 game.winlist
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,75 @@
 
 Maintainer / Developer: Alexandro G. Corrêa <alex.linux@gmail.com>
 
+## Release 05 - 11/Jul/2026
+
+### Startup: quieter FQDN-fallback warning
+
+- `getmyhostname()` (`src/net.c`) no longer `printf()`s its "could not
+  determine a fully qualified hostname" warning to stdout on every
+  startup -- expected on any host without a configured FQDN (very common
+  on containers), not an error. Still recorded in `game.log` via
+  `lvprintf()` when `verbose>=2`, for troubleshooting.
+
+### Fix: `game.conf` string values corrupted by CRLF line endings
+
+- `gameread()` (`src/game.c`) parsed each line with `"%[^\n]"`, which
+  happily includes a trailing `\r` when `game.conf` has CRLF line
+  endings. Numeric fields (`atoi()`) were silently immune, but string
+  fields copied verbatim -- `pidfile`, `bindip`, `topic` -- were not:
+  `pidfile` ended up as the literal filename `"game.pid\r"`, a
+  different name from `"game.pid"` as far as the filesystem is
+  concerned, so the daemon wrote its PID to a file nothing else could
+  ever find by its expected name. This is what caused the Docker
+  entrypoint's PID-file wait loop to time out and restart-loop, even
+  though the server itself had started up fine. Now strips a trailing
+  `\r` from each config line right after reading it.
+
+### Fix: server crash on every client connection (`read_motd()`)
+
+- `read_motd()` (`src/main.c`) looped on `"!feof(file_in)"`, which only
+  becomes true *after* a read attempt has already run past the last
+  line -- so every call did one extra, guaranteed-to-fail `fscanf()`
+  past the real content, and that ordinary end-of-file was (wrongly)
+  treated as a fatal I/O error. `fatal()` kills every connected socket
+  and `exit()`s the *whole server process*, so this crashed the entire
+  server on every client connection that got far enough to be sent the
+  MOTD (not just the one being served) -- experienced by the client as
+  an abrupt "*** Server has Shut Down" disconnect. Fixed by looping on
+  the `fscanf()` result itself.
+- Also fixed a stray `\r` in MOTD lines (same CRLF issue as above,
+  affecting `game.motd` this time), which was being sent embedded in
+  the `pline` packet right before its `\xff` terminator.
+
+### Fix: `/whois` command-prefix collision with `/who`
+
+- `/whois <nick>` also matched `/who`'s `strncasecmp(MSG, "/who", 4)`
+  check (independent, unconditional `if`s, not `else if`), since
+  `"/whois"` starts with `"/who"` -- every `/whois` dumped the full
+  `/who` player table right after the whois info. Same latent bug
+  existed between `/ban` and `/banlist`. Fixed both by requiring the
+  matched prefix be followed by end-of-string or a space.
+- `/whois`'s field labels ("Team:", "Client version:", ...) now use
+  fixed-width padding instead of a single `\t` each, so values line up
+  in the same column regardless of label length.
+
+### New: colored, boxed ASCII-art MOTD
+
+- `read_motd()` now supports an optional leading `[NAME]` colour tag
+  per line in `game.motd` (e.g. `[YELLOW]...`), stripped before
+  sending; falls back to the previous plain-blue behaviour for
+  tag-less or unrecognised tags, so old motd files keep working
+  unchanged.
+- Sends a blank `pline 0` before and after the MOTD content, from code
+  rather than as an empty line in the file itself (an empty line there
+  would silently truncate the rest of the file -- `"%[^\n]"` requires
+  at least one character).
+- New `bin/game.motd`: a boxed banner with maintainer/repo info and a
+  `/help` pointer, encoded as Windows-1252/cp1252 rather than UTF-8 --
+  the real TetriNET 1.13 client renders accented characters (e.g.
+  "Corrêa") correctly in that encoding but mangles UTF-8's multi-byte
+  sequences.
+
 ## Release 04 - 09/Jul/2026
 
 ### Admin authentication (multi-admin, nickname + password)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Maintainer / Developer: Alexandro G. Corrêa <alex.linux@gmail.com>
 
 ## Release 05 - 11/Jul/2026
 
+### Repo housekeeping
+
+- `CLAUDE.md` (guidance for Claude Code sessions working in this repo)
+  added to `.gitignore` -- kept locally, not tracked/shared via git.
+
 ### Startup: quieter FQDN-fallback warning
 
 - `getmyhostname()` (`src/net.c`) no longer `printf()`s its "could not

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,13 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Git workflow
+
+Always work on a branch named `claude` (branched from `develop`), never
+commit directly to `develop` or `main`. If `claude` doesn't exist yet,
+create it from `develop`. Check out/create it at the start of a session
+before making changes.
+
 ## What this is
 
 TetriNET X Modern is a modernized fork of `tetrinetx` (the classic GNU

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,12 @@ commit directly to `develop` or `main`. If `claude` doesn't exist yet,
 create it from `develop`. Check out/create it at the start of a session
 before making changes.
 
+Whenever you make a commit, also update `CHANGELOG.md` with a summary of
+what changed, in the same commit. Add it under the current unreleased
+entry at the top of the file, following the existing `## Release NN -
+DD/Mon/YYYY` + `### Topic` + bullet-list structure already used
+throughout the file.
+
 ## What this is
 
 TetriNET X Modern is a modernized fork of `tetrinetx` (the classic GNU

--- a/bin/game.motd
+++ b/bin/game.motd
@@ -1,3 +1,11 @@
-Welcome! TetriNET is still alive! :)
-This server is running Tetrinet X Modern
-More info: https://github.com/agcorreatech/tetrinetx-modern
+[BLACK]+=====================================================+
+[BLUE]|                          T E T R I N E T - X       M O D E R N                         |
+[BLACK]+=====================================================+
+[DARKGRAY]|                  [  ]                Classic multiplayer Tetris,                    |
+[DARKGRAY]|             [  ][  ][  ]                 reloaded for modern servers!        |
+[BLACK]+=====================================================+
+[SILVER]|   Maintainer: Alexandro G. Corrêa <alex.linux@gmail.com>  |
+[SILVER]|   Repo: https://github.com/agcorreatech/tetrinetx-modern  |
+[BLACK]+=====================================================+
+[GREEN]|     New here? Type /help to see all available commands.     |
+[BLACK]+=====================================================+

--- a/src/game.c
+++ b/src/game.c
@@ -762,7 +762,17 @@ int gameread(void)
         if(fscanf(file_in," %512[^\n]\n", buf) != 1)
         {
           printf("Error: Failed to read config file: %s.\n",FILE_CONF);
-        }        
+        }
+        /* Strip a trailing '\r' (game.conf saved/edited with CRLF line
+           endings, e.g. on Windows): %[^\n] stops at '\n' but happily
+           includes a preceding '\r' as a normal character. Left alone,
+           that '\r' ends up stuck onto whatever value follows an '='
+           (pidfile, bindip, topic, ...), which is invisible in most
+           displays but corrupts filenames/behaviour built from it --
+           e.g. pidfile becoming "game.pid\r", a different filename from
+           "game.pid" as far as the filesystem is concerned. */
+        j=strlen(buf);
+        if (j>0 && buf[j-1]=='\r') buf[j-1]='\0';
         i=0; j=strlen(buf);
         while( (i<j) && (buf[i]!='#') ) i++;
         if (buf[i]=='#') buf[i] = '\0'; /* Truncate string to # char */

--- a/src/main.c
+++ b/src/main.c
@@ -1025,7 +1025,13 @@ void net_connected(struct net_t *n, char *buf)
                    and disconnects them for real (unlike /kick, which only
                    redirects to the lobby -- a ban means they can't reconnect
                    at all until /unban'ed). */
-                if ( !strncasecmp(MSG, "/ban", 4) && (game.command_ban>0) )
+                /* Boundary check ("ban"[4] must be end-of-string or a
+                   space): without it, "/banlist" also starts with "/ban"
+                   and would trigger THIS handler too, dumping a spurious
+                   "Usage: /ban <playernumber> [reason]" alongside the
+                   actual banlist output. Same class of bug as /who vs
+                   /whois above. */
+                if ( !strncasecmp(MSG, "/ban", 4) && (MSG[4]=='\0' || MSG[4]==' ') && (game.command_ban>0) )
                   {
                     valid_param=2;
                     if ( passed_level(n,game.command_ban) )
@@ -1166,10 +1172,15 @@ void net_connected(struct net_t *n, char *buf)
                                   {
                                     found_whois=1;
 
+                                    /* Labels are left-padded to a fixed width (instead of a
+                                       single '\t' after each, which lands at wildly different
+                                       columns depending on the label's own length) so every
+                                       value lines up in the same column regardless of label
+                                       length -- "Client version:" is the longest at 16 chars. */
                                     tprintf(n->sock,"pline 0 %cWhois: %s\xff", NAVY, nsock->nick);
-                                    tprintf(n->sock,"pline 0   %cTeam:\t%s\xff", BLACK, nsock->team);
-                                    tprintf(n->sock,"pline 0   %cChannel:\t#%s\xff", BLACK, nsock->channel->name);
-                                    tprintf(n->sock,"pline 0   %cSlot:\t%d\xff", BLACK, nsock->gameslot);
+                                    tprintf(n->sock,"pline 0   %c%-17s%s\xff", BLACK, "Team:", nsock->team);
+                                    tprintf(n->sock,"pline 0   %c%-17s#%s\xff", BLACK, "Channel:", nsock->channel->name);
+                                    tprintf(n->sock,"pline 0   %c%-17s%d\xff", BLACK, "Slot:", nsock->gameslot);
 
                                     switch (nsock->status)
                                       {
@@ -1177,15 +1188,15 @@ void net_connected(struct net_t *n, char *buf)
                                         case STAT_LOST:     statusdesc="Lost (waiting for game to end)"; break;
                                         default:            statusdesc="Not playing"; break;
                                       }
-                                    tprintf(n->sock,"pline 0   %cStatus:\t%s\xff", BLACK, statusdesc);
+                                    tprintf(n->sock,"pline 0   %c%-17s%s\xff", BLACK, "Status:", statusdesc);
 
                                     if (nsock->status==STAT_PLAYING)
-                                      tprintf(n->sock,"pline 0   %cLevel:\t%d\xff", BLACK, nsock->level);
+                                      tprintf(n->sock,"pline 0   %c%-17s%d\xff", BLACK, "Level:", nsock->level);
 
-                                    tprintf(n->sock,"pline 0   %cClient version:\t%s\xff", BLACK, nsock->version);
+                                    tprintf(n->sock,"pline 0   %c%-17s%s\xff", BLACK, "Client version:", nsock->version);
 
                                     if (passed_level(n,LEVEL_AUTHOP))
-                                      tprintf(n->sock,"pline 0   %cHost/IP:\t%s\xff", BLACK, nsock->host);
+                                      tprintf(n->sock,"pline 0   %c%-17s%s\xff", BLACK, "Host/IP:", nsock->host);
                                   }
                                 nsock=nsock->next;
                               }
@@ -1490,7 +1501,11 @@ void net_connected(struct net_t *n, char *buf)
                   }
                   
                 /* Who is online */
-                if ( !strncasecmp(MSG, "/who", 4) && (game.command_who>0))
+                /* Boundary check ("who"[4] must be end-of-string or a
+                   space): without it, "/whois <nick>" also starts with
+                   "/who" and would trigger THIS handler too, dumping an
+                   unwanted full player list right after the whois info. */
+                if ( !strncasecmp(MSG, "/who", 4) && (MSG[4]=='\0' || MSG[4]==' ') && (game.command_who>0))
                   {
                     valid_param=2;
                     if ( passed_level(n,game.command_who) )

--- a/src/main.c
+++ b/src/main.c
@@ -2756,32 +2756,40 @@ void read_motd(struct net_t *n)
   char motd[1024];
 
   file_in = fopen(FILE_MOTD,"r");
- 
+
   /* File exists, so read it */
   if (file_in != NULL)
   {
-    while (!feof(file_in))
+    /* BUGFIX: this used to loop on "!feof(file_in)", which only becomes
+       true AFTER a read attempt has already run past the last line -- so
+       every call did one extra, guaranteed-to-fail fscanf() beyond the
+       real content, and that ordinary end-of-file was (wrongly) treated
+       as a fatal I/O error. fatal() kills every connected socket and
+       exit()s the WHOLE server process, so this crashed the entire
+       server on every single client connection (any connection that got
+       far enough to be sent the MOTD), not just the one being served.
+       Looping on the fscanf() result itself avoids the spurious extra
+       iteration entirely. */
+    while (fscanf(file_in,"%1023[^\n]\n", motd) == 1)
     {
-      
-      if(fscanf(file_in,"%1023[^\n]\n", motd) != 1)
-      {
-        lvprintf(4,"ERROR: Failed to read MOTD file. Check folder permissions or remove the file.\n");
-        fatal("Failed to read MOTD file. Check folder permissions or remove the file.",0);
-      }
-      else {
-        tprintf(n->sock,"pline 0 %c%c%s\xff", BOLD, BLUE, motd);
-      }
+      /* Strip a trailing '\r' (game.motd saved/edited with CRLF line
+         endings): "%[^\n]" stops at '\n' but includes a preceding '\r'
+         as an ordinary character, which would otherwise be sent
+         verbatim, embedded in the "pline" packet right before its
+         terminating '\xff'. */
+      int mlen = strlen(motd);
+      if (mlen>0 && motd[mlen-1]=='\r') motd[mlen-1]='\0';
+      tprintf(n->sock,"pline 0 %c%c%s\xff", BOLD, BLUE, motd);
     }
-  
+
     lvprintf(4,"File game.motd read successfully.\n");
+    fclose(file_in);
   }
   else
   {
     lvprintf(4,"ERROR: Failed to read MOTD file. Check folder permissions or remove the file.\n");
     fatal("Failed to read MOTD file. Check folder permissions or remove the file.",0);
   }
-
-  fclose(file_in);
 }
 
 /* Write a new the MOTD file with defaults */

--- a/src/main.c
+++ b/src/main.c
@@ -2764,6 +2764,27 @@ void net_waitingforteam(struct net_t *n, char *buf)
     lvprintf(2,"#%s-%s New connection\n", n->channel->name,n->nick);
   }
 
+/* Named colours a game.motd line can request via a leading "[NAME]" tag
+   (see read_motd() below). Names match the #define's in main.h. */
+struct motd_colour_t { const char *name; int code; };
+static const struct motd_colour_t motd_colours[] = {
+  { "BLACK",    BLACK },
+  { "DARKGRAY", DARKGRAY },
+  { "SILVER",   SILVER },
+  { "NAVY",     NAVY },
+  { "BLUE",     BLUE },
+  { "CYAN",     CYAN },
+  { "GREEN",    GREEN },
+  { "NEON",     NEON },
+  { "TEAL",     TEAL },
+  { "BROWN",    BROWN },
+  { "RED",      RED },
+  { "MAGENTA",  MAGENTA },
+  { "VIOLET",   VIOLET },
+  { "YELLOW",   YELLOW },
+  { "WHITE",    WHITE },
+};
+
 /* Read the MOTD file */
 void read_motd(struct net_t *n)
 {
@@ -2775,6 +2796,12 @@ void read_motd(struct net_t *n)
   /* File exists, so read it */
   if (file_in != NULL)
   {
+    /* Blank line before the MOTD content. Sent from code, not as a blank
+       line in game.motd itself: an empty line there would fail to match
+       "%[^\n]" (it requires at least one character), silently ending the
+       read loop right there and skipping everything after it. */
+    tprintf(n->sock,"pline 0 \xff");
+
     /* BUGFIX: this used to loop on "!feof(file_in)", which only becomes
        true AFTER a read attempt has already run past the last line -- so
        every call did one extra, guaranteed-to-fail fscanf() beyond the
@@ -2787,15 +2814,49 @@ void read_motd(struct net_t *n)
        iteration entirely. */
     while (fscanf(file_in,"%1023[^\n]\n", motd) == 1)
     {
+      char *text;
+      int colour, mlen, i;
+
       /* Strip a trailing '\r' (game.motd saved/edited with CRLF line
          endings): "%[^\n]" stops at '\n' but includes a preceding '\r'
          as an ordinary character, which would otherwise be sent
          verbatim, embedded in the "pline" packet right before its
          terminating '\xff'. */
-      int mlen = strlen(motd);
+      mlen = strlen(motd);
       if (mlen>0 && motd[mlen-1]=='\r') motd[mlen-1]='\0';
-      tprintf(n->sock,"pline 0 %c%c%s\xff", BOLD, BLUE, motd);
+
+      /* Optional per-line colour: a leading "[NAME]" tag (NAME one of
+         motd_colours[] above) picks the colour for that line and is
+         stripped before sending; anything else -- no tag, or an
+         unrecognised name -- falls back to the original plain BLUE,
+         sent exactly as written (keeps old, tag-less motd files working
+         unchanged). */
+      text = motd;
+      colour = BLUE;
+      if (motd[0]=='[')
+      {
+        char *close = strchr(motd, ']');
+        if (close != NULL)
+        {
+          *close = '\0';
+          for (i=0; i < (int)(sizeof(motd_colours)/sizeof(motd_colours[0])); i++)
+          {
+            if (!strcasecmp(motd+1, motd_colours[i].name))
+            {
+              colour = motd_colours[i].code;
+              text = close+1;
+              break;
+            }
+          }
+          if (text == motd) *close = ']'; /* not a recognised tag -- restore and send as-is */
+        }
+      }
+
+      tprintf(n->sock,"pline 0 %c%c%s\xff", BOLD, colour, text);
     }
+
+    /* Blank line after the MOTD content, mirroring the one before it. */
+    tprintf(n->sock,"pline 0 \xff");
 
     lvprintf(4,"File game.motd read successfully.\n");
     fclose(file_in);


### PR DESCRIPTION
## Summary
- Fixed several bugs found while getting the server running end-to-end in Docker Desktop and testing with a real TetriNET 1.13 client for the first time:
  - Quieter FQDN-fallback warning on startup (no longer printed to stdout on every boot).
  - `game.conf` string values (`pidfile`, `bindip`, `topic`) getting a stray `\r` when the file has CRLF line endings — this is what caused the Docker container to restart-loop (the daemon wrote its PID to a file named `game.pid\r`, never found by the entrypoint's wait loop).
  - `read_motd()` crashed the **entire server process** on every client connection that reached the MOTD step (a `while(!feof())` anti-pattern triggered a spurious `fatal()`) — the real root cause behind "*** Server has Shut Down" in the client.
  - `/whois` triggering `/who`'s handler too (prefix-collision bug, `/ban`/`/banlist` had the same latent issue), plus `/whois` column alignment.
- Added a colored, boxed ASCII-art MOTD with maintainer/repo info and a `/help` pointer, encoded in Windows-1252 (the real client mangles UTF-8 accented characters), with a blank line before/after.
- Documented the git workflow (work on `claude`, branched from `develop`) and the changelog-per-commit convention in `CLAUDE.md` (now gitignored, kept local-only).
- Backfilled `CHANGELOG.md` (Release 05) for all of the above.

## Test plan
- [x] Built and ran the server via `contrib/docker/docker-compose.yml` on Docker Desktop.
- [x] Connected with the real TetriNET 1.13 Windows client, verified: connection no longer drops after MOTD, MOTD renders correctly (colors, alignment, accents), `/who`, `/whois`, chat, team join all work as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)